### PR TITLE
Fix illegal String format

### DIFF
--- a/src/org/crf/crf/CrfUtilities.java
+++ b/src/org/crf/crf/CrfUtilities.java
@@ -237,7 +237,7 @@ public class CrfUtilities
 		if ( ( (valueToAdd<0.0) && (oldValue<variable) ) || ( (valueToAdd>0.0) && (oldValue>variable) ) )
 		{
 			throw new CrfException("Error: adding value to \"double\" variable yielded unexpected results. This seems like a limitation of double."
-					+ "variable was: "+String.format("%-3.3", oldValue)+", value to add was: "+String.format("%-3.3f", valueToAdd));
+					+ "variable was: "+String.format("%1$.3f", oldValue)+", value to add was: "+String.format("%1$.3f", valueToAdd));
 		}
 		return variable;
 	}


### PR DESCRIPTION
See [Java documentation on Formatter syntax](http://docs.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html#syntax); Java will throw an error when it encounters `"%-3.3"` as a String format.
